### PR TITLE
Separate seasons by ISO 8601 week

### DIFF
--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -9,8 +9,16 @@ class Season
     new latest_year
   end
 
+  def start_date
+    Date.commercial(@year, 1).beginning_of_day
+  end
+
+  def end_date
+    (Date.commercial(@year + 1, 1) - 1.day).end_of_day
+  end
+
   def date_range
-    time.beginning_of_year..time.end_of_year
+    start_date..end_date
   end
 
   def games
@@ -32,10 +40,7 @@ class Season
   private
 
   def self.latest_year
-    Time.current.year
+    Time.current.to_date.cwyear
   end
 
-  def time
-    Time.new(@year)
-  end
 end

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Season do
+  let(:season) { Season.new(year) }
+
+  def date(s)
+    Date.parse(s)
+  end
+
+  shared_examples "ISO 8601 week based date range" do
+    let(:first_day) { subject.begin.to_date }
+    let(:last_day) { subject.end.to_date }
+
+    it "starts on the first week of the year" do
+      expect(first_day.cwyear).to eq(year)
+      expect(first_day.cweek).to eq(1)
+    end
+
+    it "ends on a week of the same year" do
+      expect(last_day.cwyear).to eq(year)
+    end
+
+    it "starts immediately after the last week of previous year" do
+      prev_day = first_day - 1.day
+      expect(prev_day.cwyear).to eq(year - 1)
+    end
+
+    it "ends immediately before the first week of the following year" do
+      next_day = last_day + 1.day
+      expect(next_day.cwyear).to eq(year + 1)
+      expect(next_day.cweek).to eq(1)
+    end
+  end
+
+  describe '#date_range' do
+    subject { season.date_range }
+    context '2014' do
+      let(:year) { 2014 }
+
+      it_behaves_like "ISO 8601 week based date range"
+
+      it { should cover(date("2014-01-01")) }
+      it { should cover(date("2014-12-29")) }
+      it { should_not cover(date("2014-12-30")) }
+      it { should_not cover(date("2015-01-01")) }
+    end
+
+    context '2015' do
+      let(:year) { 2015 }
+
+      it { should cover(date("2014-12-30")) }
+      it { should cover(date("2015-01-01")) }
+      it { should cover(date("2016-01-01")) }
+      it { should cover(date("2016-01-04")) }
+
+      it { should_not cover(date("2014-12-29")) }
+      it { should_not cover(date("2016-01-05")) }
+
+      it_behaves_like "ISO 8601 week based date range"
+    end
+
+    (2016..2020).each do |y|
+      context y.to_s do
+        let(:year) { y }
+        it_behaves_like "ISO 8601 week based date range"
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -110,8 +110,9 @@ describe User do
     end
 
     context "with provided season" do
+      let(:season) { Season.new(1.year.ago.year) }
       before do
-        Timecop.freeze(1.year.ago) do
+        Timecop.freeze(season.date_range.begin) do
           game = create :game, ended_at: Time.now
 
           answer1 = create :answer, game: game
@@ -122,7 +123,7 @@ describe User do
         end
       end
 
-      subject { user.correct_ratio(Season.new(1.year.ago.year)) }
+      subject { user.correct_ratio(season) }
 
       it { is_expected.to eq 0.5 }
     end


### PR DESCRIPTION
:heart: :heart: :heart: ISO 8601 :heart: :heart: :heart:

Imperilment is split into "seasons" lasting one year.

Currently, we have two pieces of conflicting logic to determine which season a game is in:

* The leaderboard page shows the week of the game, which is the week of the year the game ends on `@game.ended_at.strftime("%V")`
* The `Season` model uses the year of the ***day*** of the game's end, rather than the year of the week. 

This year those are different. This week's game ends on January 2nd 2016, but that is still a 2015 week.

```
Date.parse("2016-01-02").year    #=> 2016
Date.parse("2016-01-02").cwyear  #=> 2015
```

This PR moves us to ISO 8601 weeks everywhere because ISO 8601 is awesome and I love it. It will cause our current game to be the game of the 53rd week of the 2015 season.

This does not change our historic data. Our "new years" game last year ended on 2015-01-04 and was considered part of this year, as it still would using ISO 8601.