### PR TITLE
Add Markdown formatting to Answer notifications

### DIFF
--- a/app/models/slack_notification/new_answer.rb
+++ b/app/models/slack_notification/new_answer.rb
@@ -14,6 +14,7 @@ class SlackNotification::NewAnswer < SlackNotification
       text: @answer.answer || "",
       color: "#337AB7",
       fallback: "#{pretext} #{game_answer_url(@answer.game, @answer)}",
+      mrkdwn_in: %w(text),
     }]
   end
 

--- a/spec/models/slack_notification/new_answer_spec.rb
+++ b/spec/models/slack_notification/new_answer_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe SlackNotification::NewAnswer, type: :model do
         'title_link' => "http://test.com/games/#{answer.game.id}/answers/#{answer.id}",
         'text' => 'What is fail?',
         'color' => '#337AB7',
-        'fallback' => "New Imperilment clue! http://test.com/games/#{answer.game.id}/answers/#{answer.id}"
+        'fallback' => "New Imperilment clue! http://test.com/games/#{answer.game.id}/answers/#{answer.id}",
+        "mrkdwn_in" => ["text"]
       }]
     end
 
@@ -52,7 +53,8 @@ RSpec.describe SlackNotification::NewAnswer, type: :model do
           'title_link' => "http://test.com/games/#{answer.game.id}/answers/#{answer.id}",
           'text' => '',
           'color' => '#337AB7',
-          'fallback' => "Final Imperilment! http://test.com/games/#{answer.game.id}/answers/#{answer.id}"
+          'fallback' => "Final Imperilment! http://test.com/games/#{answer.game.id}/answers/#{answer.id}",
+          "mrkdwn_in" => ["text"]
         }]
       end
     end


### PR DESCRIPTION
This is a weirdly-documented feature in Slack's Attachment API, but you
can have markdown-formatted text in message attachments.

For more details: https://api.slack.com/docs/formatting