### PR TITLE
Future answer access restrictions

### DIFF
--- a/app/helpers/leader_board_helper.rb
+++ b/app/helpers/leader_board_helper.rb
@@ -28,7 +28,7 @@ module LeaderBoardHelper
   end
 
   def status_for(answer)
-    if !answer
+    if !answer || !Answer.active.exists?(answer.id)
       :unavailable
     elsif !(question = answer.question_for(current_user))
       :unanswered

--- a/app/helpers/leader_board_helper.rb
+++ b/app/helpers/leader_board_helper.rb
@@ -28,7 +28,7 @@ module LeaderBoardHelper
   end
 
   def status_for(answer)
-    if !answer || !Answer.active.exists?(answer.id)
+    if !answer || !answer.active?
       :unavailable
     elsif !(question = answer.question_for(current_user))
       :unanswered

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,7 +21,7 @@ class Ability
       end
       can :read, Game
       can :read, Answer do |answer|
-        Answer.active.exists?(answer.id)
+        answer.active?
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,7 +20,9 @@ class Ability
         question.answer.closed?
       end
       can :read, Game
-      can :read, Answer
+      can :read, Answer do |answer|
+        Answer.active.exists?(answer.id)
+      end
     end
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,6 @@
 class Answer < ActiveRecord::Base
+  scope :active, -> { where("start_date <= ?", effective_date) }
+
   belongs_to :game
   belongs_to :category
 
@@ -9,7 +11,7 @@ class Answer < ActiveRecord::Base
   validates :start_date, uniqueness: true
 
   def self.most_recent
-    where('start_date <= ?', DateTime.now).order('start_date DESC').first
+    where('start_date <= ?', effective_date).order('start_date DESC').first
   end
 
   def self.next_free_date
@@ -22,6 +24,16 @@ class Answer < ActiveRecord::Base
 
   def self.last_answer
     order(:start_date).last
+  end
+
+  # Adjust date to include Saturday in Friday's release, and postpone Sunday until Monday's release
+  def self.effective_date
+    today = Time.zone.now
+
+    today += 1.day if today.friday?
+    today -= 1.day if today.sunday?
+
+    today
   end
 
   def questions_by_user_id

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -55,4 +55,8 @@ class Answer < ActiveRecord::Base
   def final?
     !amount
   end
+
+  def active?
+    Answer.active.exists?(self.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,8 @@ class User < ActiveRecord::Base
       joins(:game).
       where(games: { locked: false }).
       where(questions: { id: nil }).
-      order(:start_date)
+      order(:start_date).
+      merge(Answer.active)
   end
 
   def correct_ratio(season = nil)

--- a/spec/helpers/leader_board_helper_spec.rb
+++ b/spec/helpers/leader_board_helper_spec.rb
@@ -58,12 +58,16 @@ describe LeaderBoardHelper do
       let(:answer) { nil }
       it { is_expected.to eq(:unavailable) }
     end
+    context 'future answer' do
+      let(:answer) { double(:answer, active?: false) }
+      it { is_expected.to eq(:unavailable) }
+    end
     context 'nil question' do
-      let(:answer) { double(:answer, question_for: nil) }
+      let(:answer) { double(:answer, question_for: nil, active?: true) }
       it { is_expected.to eq(:unanswered) }
     end
     context 'nil question' do
-      let(:answer) { double(:answer, question_for: question) }
+      let(:answer) { double(:answer, question_for: question, active?: true) }
       let(:question) { double(:question, status: :foobar) }
       it { is_expected.to eq(:foobar) }
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -22,7 +22,20 @@ describe Ability do
   context 'when user is not an administrator' do
     it { is_expected.to be_able_to :index, Question }
     it { is_expected.to be_able_to :read, Game }
-    it { is_expected.to be_able_to :read, Answer }
+
+    describe 'reading answers' do
+      let(:answer) { build_stubbed :answer }
+
+      context 'when answer is inactive' do
+        before(:each) { allow(answer).to receive(:active?) { false } }
+        it { is_expected.not_to be_able_to :read, answer }
+      end
+
+      context 'when answer is active' do
+        before(:each) { allow(answer).to receive(:active?) { true } }
+        it { is_expected.to be_able_to :read, answer }
+      end
+    end
 
     describe 'managing questions' do
       context 'when question is for user' do

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -63,4 +63,54 @@ describe Answer do
       it { is_expected.to be_truthy }
     end
   end
+
+  describe '.active?' do
+    let!(:sat_answer) { create :answer, start_date: '2016-08-13 00:00:00' }
+    let!(:sun_answer) { create :answer, start_date: '2016-08-14 00:00:00' }
+    let!(:today_answer) { create :answer, start_date: Time.zone.now }
+
+    context "when the answer is active" do
+      subject { first.active? }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the answer is inactive" do
+      subject { third.active? }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when the answer is for a Saturday" do
+      subject { sat_answer.active? }
+      it "should be active on Friday" do
+        Timecop.freeze(Time.zone.local(2016, 8, 12, 0, 0, 0)) do
+          expect(sat_answer.active?).to be_truthy
+        end
+      end
+
+      it "should be active on Saturday" do
+        Timecop.freeze(Time.zone.local(2016, 8, 13, 0, 0, 0)) do
+          expect(sat_answer.active?).to be_truthy
+        end
+      end
+    end
+
+    context "when the answer is for a Sunday" do
+      it "should be inactive on Sunday" do
+        Timecop.freeze(Time.zone.local(2016, 8, 14, 0, 0, 0)) do
+          expect(sun_answer.active?).to be_falsey
+        end
+      end
+
+      it "should be active on Monday" do
+        Timecop.freeze(Time.zone.local(2016, 8, 15, 0, 0, 0)) do
+          expect(sun_answer.active?).to be_truthy
+        end
+      end
+    end
+
+    context "when the answer is for today" do
+      subject { today_answer.active? }
+      it { is_expected.to be_truthy }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,6 +66,11 @@ describe User do
     let!(:answer) { create :answer, game: game }
     subject { user.pending_answers }
 
+    context "Answer from the future exists" do
+      let!(:future_answer) { create :answer, game: game, start_date: '9999-01-03 00:00:00' }
+      it { is_expected.to eq [answer] }
+    end
+
     context "Answer has question from same user" do
       let!(:question) { create :question, answer: answer, user: user }
       it { is_expected.to eq [] }


### PR DESCRIPTION
This PR is intended to restrict access to answers when the `start_date` is before today's date. This allows answers to be pre-populated without altering the game flow or visual representation for users.

The `active?` instance method added to the `Answer` model defines an answer as active if the answer's `start_date` is on or before today's effective date*. The answer is restricted in the `Ability` model by removing `read` permissions on inactive answers to normal users (admins retain access). The link in the answer nav is not shown to users by returning the `unavailable` flag for inactive answers in `LeaderBoardHelper.status_for`.

*effective date is today's date adjusted to allow Saturday's question to show on Friday, and postpone Sunday's question until Monday.