### PR TITLE
Replace unquestioned answers for admin in answers#index

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -6,8 +6,9 @@ class AnswersController < ApplicationController
   respond_to :html
 
   def index
+    @blocked = "~~ Provide a question for this answer to see this content. ~~"
     @answers = @answers.page(params[:page])
-    respond_with @game, @answers
+    respond_with @game, @answers, @blocked
   end
 
   def show

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -33,7 +33,7 @@ class Answer < ActiveRecord::Base
     today += 1.day if today.friday?
     today -= 1.day if today.sunday?
 
-    today
+    today.change(hour: 0)
   end
 
   def questions_by_user_id

--- a/app/views/answers/index.html.erb
+++ b/app/views/answers/index.html.erb
@@ -30,8 +30,8 @@
         </td>
         <td class='day'><%= answer.start_date.strftime('%a') %></td>
         <td>
-          <p><strong><%= answer.category.try(:name) %></strong></p>
-          <p><%= answer.answer %></p>
+          <p><strong><%= answer.active? ? answer.category.try(:name) : @blocked %></strong></p>
+          <p><%= answer.active? ? answer.answer : @blocked %></p>
         </td>
         <td class='amount'><%= number_to_currency answer.amount, precision: 0, unit: t(:currency_symbol) %></td>
         <td class='hidden-phone'>

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -68,6 +68,7 @@ describe Answer do
     let!(:sat_answer) { create :answer, start_date: '2016-08-13 00:00:00' }
     let!(:sun_answer) { create :answer, start_date: '2016-08-14 00:00:00' }
     let!(:today_answer) { create :answer, start_date: Time.zone.now }
+    let!(:tom_answer) { create :answer, start_date: (Time.zone.now + 1.day).change(hour: 0) }
 
     context "when the answer is active" do
       subject { first.active? }
@@ -111,6 +112,14 @@ describe Answer do
     context "when the answer is for today" do
       subject { today_answer.active? }
       it { is_expected.to be_truthy }
+    end
+
+    context "when today is in the afternoon" do
+      it "tomorrow's answer should be inactive" do
+        Timecop.freeze(Time.zone.local(Time.zone.now.year, Time.zone.now.month,
+                                       Time.zone.now.day, 22, 0, 0))
+        expect(tom_answer.active?).to be_falsey
+      end
     end
   end
 end


### PR DESCRIPTION
An admin visiting the `answers#index` page (for example, on the way to marking questions) will see all answers for the current week. This is especially a problem for Final Jeopardy, as seeing the answer in advance would impact the admin's wager amount.

This PR:

1. Adds a style to blur text, and disallow selecting that text (which would reveal the contents).
2. Adds the blurred text style to answers on `answers#index` if the admin has not provided a question yet for that day.