### PR TITLE
Final game notification should reference last week instead of this week

### DIFF
--- a/app/models/slack_notification/game_finalization.rb
+++ b/app/models/slack_notification/game_finalization.rb
@@ -9,11 +9,11 @@ class SlackNotification::GameFinalization < SlackNotification
   def attachments
     [{
       pretext: "Imperilment results are in!",
-      title: "This week's winners",
+      title: "Last week's winners",
       title_link: leader_board_url(@game.id),
       text: podium_text,
       color: "#337AB7",
-      fallback: "This week's winners are in! #{leader_board_url(@game.id)}",
+      fallback: "Last week's winners are in! #{leader_board_url(@game.id)}",
     }]
   end
 

--- a/spec/models/slack_notification/game_finalization_spec.rb
+++ b/spec/models/slack_notification/game_finalization_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe SlackNotification::GameFinalization, type: :model do
     it 'has the correct attachments' do
       expect(subject['attachments']).to eq [{
         'pretext' => 'Imperilment results are in!',
-        'title' => "This week's winners",
+        'title' => "Last week's winners",
         'title_link' => 'http://test.com/leader_board/772',
         'text' => ":trophy: $4200 First P\n\n:silver: $2500 foo@bar.com\n\n:silver: $2500 Also 2",
         'color' => '#337AB7',
-        'fallback' => "This week's winners are in! http://test.com/leader_board/772"
+        'fallback' => "Last week's winners are in! http://test.com/leader_board/772"
       }]
     end
   end


### PR DESCRIPTION
#37 Change game finalization notification text

Changed the text in the slack_notification model