### PR TITLE
Don't post slack notifications

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -50,7 +50,6 @@ class AnswersController < ApplicationController
     @answer.game = @game
     if @answer.save
       flash.notice = t :model_create_successful, model: Answer.model_name.human
-      SlackNotification::NewAnswer.new(@answer).deliver
     end
     respond_with @game, @answer
   end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -108,13 +108,6 @@ describe AnswersController do
   end
 
   describe "POST create" do
-    let(:slack_webhook_url) { 'http://slack.com' }
-    let!(:mock) { stub_request(:any, slack_webhook_url) }
-
-    before do
-      ENV['SLACK_WEBHOOK_URL'] = slack_webhook_url
-    end
-
     describe "with valid params" do
       subject { post :create, default_params }
       it "creates a new Answer" do
@@ -127,11 +120,6 @@ describe AnswersController do
         subject
         expect(assigns(:answer)).to be_a(Answer)
         expect(assigns(:answer)).to be_persisted
-      end
-
-      it "sends a Slack api notification" do
-        subject
-        expect(mock).to have_been_made
       end
 
       it "redirects to the created answer" do


### PR DESCRIPTION
To support automatically generated games, slack notifications should not
be generated when an answer is created. Otherwise notifications are
generated when the answer is created instead of when the answer can be
questioned.