### PR TITLE
Slack announcements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'rack-mini-profiler'
 gem 'flamegraph'
 gem 'stackprof'
 gem 'memory_profiler'
+gem 'whenever'
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.10.2)
     cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.1.0)
@@ -334,6 +335,8 @@ GEM
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
     will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -392,4 +395,8 @@ DEPENDENCIES
   unicorn
   validate_url
   webmock
+  whenever
   will_paginate
+
+BUNDLED WITH
+   1.12.5

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,5 +1,7 @@
 class Answer < ActiveRecord::Base
   scope :active, -> { where("start_date <= ?", effective_date) }
+  scope :announceable, -> { where("start_date <= ? AND start_date >= ?",
+                                 effective_date, announce_date) }
 
   belongs_to :game
   belongs_to :category
@@ -28,12 +30,20 @@ class Answer < ActiveRecord::Base
 
   # Adjust date to include Saturday in Friday's release, and postpone Sunday until Monday's release
   def self.effective_date
-    today = Time.zone.now
+    today = Date.current
 
     today += 1.day if today.friday?
     today -= 1.day if today.sunday?
 
-    today.change(hour: 0)
+    today
+  end
+
+  def self.announce_date
+    today = Date.current
+
+    today -= 1.day if today.monday?
+
+    today
   end
 
   def questions_by_user_id

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every :weekday, at: '10am' do
+  rake "notify_slack:post_answers"
+end

--- a/lib/tasks/notify_slack.rake
+++ b/lib/tasks/notify_slack.rake
@@ -1,0 +1,8 @@
+namespace :notify_slack do
+  desc "Post Answer notifications to Slack for announceable answers"
+  task :post_answers => :environment do
+    Answer.announceable.each do |ans|
+      SlackNotification::NewAnswer.new(ans).deliver
+    end
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -67,30 +67,30 @@ describe Answer do
   describe '.active?' do
     let!(:sat_answer) { create :answer, start_date: '2016-08-13 00:00:00' }
     let!(:sun_answer) { create :answer, start_date: '2016-08-14 00:00:00' }
-    let!(:today_answer) { create :answer, start_date: Time.zone.now }
-    let!(:tom_answer) { create :answer, start_date: (Time.zone.now + 1.day).change(hour: 0) }
+    let!(:today_answer) { create :answer, start_date: Date.current }
+    let!(:tom_answer) { create :answer, start_date: Date.tomorrow }
 
     context "when the answer is active" do
-      subject { first.active? }
-      it { is_expected.to be_truthy }
+      subject { first }
+      it { is_expected.to be_active }
     end
 
     context "when the answer is inactive" do
-      subject { third.active? }
-      it { is_expected.to be_falsey }
+      subject { third }
+      it { is_expected.not_to be_active }
     end
 
     context "when the answer is for a Saturday" do
       subject { sat_answer.active? }
       it "should be active on Friday" do
         Timecop.freeze(Time.zone.local(2016, 8, 12, 0, 0, 0)) do
-          expect(sat_answer.active?).to be_truthy
+          expect(sat_answer).to be_active
         end
       end
 
       it "should be active on Saturday" do
         Timecop.freeze(Time.zone.local(2016, 8, 13, 0, 0, 0)) do
-          expect(sat_answer.active?).to be_truthy
+          expect(sat_answer).to be_active
         end
       end
     end
@@ -98,27 +98,27 @@ describe Answer do
     context "when the answer is for a Sunday" do
       it "should be inactive on Sunday" do
         Timecop.freeze(Time.zone.local(2016, 8, 14, 0, 0, 0)) do
-          expect(sun_answer.active?).to be_falsey
+          expect(sun_answer).not_to be_active
         end
       end
 
       it "should be active on Monday" do
         Timecop.freeze(Time.zone.local(2016, 8, 15, 0, 0, 0)) do
-          expect(sun_answer.active?).to be_truthy
+          expect(sun_answer).to be_active
         end
       end
     end
 
     context "when the answer is for today" do
-      subject { today_answer.active? }
-      it { is_expected.to be_truthy }
+      subject { today_answer }
+      it { is_expected.to be_active }
     end
 
     context "when today is in the afternoon" do
       it "tomorrow's answer should be inactive" do
         Timecop.freeze(Time.zone.local(Time.zone.now.year, Time.zone.now.month,
                                        Time.zone.now.day, 22, 0, 0))
-        expect(tom_answer.active?).to be_falsey
+        expect(tom_answer).not_to be_active
       end
     end
   end


### PR DESCRIPTION
This PR will re-integrate slack announcements to Imperilment.

Using the Whenever gem, a new `Answer` scope, and a rake task, slack notifications should occur every weekday, and every answer should be announced throughout the week.