### PR TITLE
Upgrade to fontello_rails_converter 0.4.4 for .woff2 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     ffaker (2.1.0)
     flamegraph (0.1.0)
       fast_stack
-    fontello_rails_converter (0.4.2)
+    fontello_rails_converter (0.4.4)
       activesupport
       launchy
       rest-client


### PR DESCRIPTION
Add support for `.woff2` files through fontello by upgrading to
`fontello_rails_converter` [0.4.4](https://github.com/railslove/fontello_rails_converter/pull/41).
Thus, fontello glyphs can be added simply through

`bundle exec fontello open` -> select glyphs -> "Save Session"
`bundle exec fontello download`
`bundle exec fontello convert`

Which would not work due to `fontello_rails_converter` not downloading
the `.woff2` file.