### PR TITLE
Fix submitting new answer twice

### DIFF
--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -19,7 +19,7 @@
     </div>
   <% end %>
 
-  <%# Note: "this.disabled = true" prevents the button from being clicked twice and the form %>
+  <%# Note: "disable_with" prevents the button from being clicked twice and the form %>
   <%#   from submitting twice. %>
   <%= f.button :submit, class: 'btn btn-primary', data: {disable_with: "Creating Answer"} %>
 <% end %>

--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -19,5 +19,7 @@
     </div>
   <% end %>
 
-  <%= f.button :submit, class: 'btn btn-primary' %>
+  <%# Note: "this.disabled = true" prevents the button from being clicked twice and the form %>
+  <%#   from submitting twice. %>
+  <%= f.button :submit, class: 'btn btn-primary', data: {disable_with: "Creating Answer"} %>
 <% end %>


### PR DESCRIPTION
Disable the "Create Answer" button once it has been clicked. Before,
double clicking the button would cause the server to try and create 2
answers with the same start date, and it would tell the user "An answer
with that start date already exists".

Will close #40 

Ex:
![double-click-imperilment-trimmed](https://user-images.githubusercontent.com/5296849/28643399-9202b2bc-720a-11e7-8f0a-311cdfb10fdd.gif)
