### PR TITLE
Add in office leader boards

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -42,6 +42,6 @@ class Admin::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit :email, :password, :password_confirmation, :remember_me, :first_name, :last_name
+    params.require(:user).permit :email, :password, :password_confirmation, :remember_me, :first_name, :last_name, :in_office
   end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -5,5 +5,8 @@
   <%= f.input :first_name %>
   <%= f.input :last_name %>
 
+  <%= f.check_box :in_office, {checked: @user.in_office} %>
+  <%= f.label :in_office %> <br>
+
   <%= f.button :submit, class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/leader_boards/_results.html.erb
+++ b/app/views/leader_boards/_results.html.erb
@@ -9,23 +9,27 @@
   </thead>
   <tbody>
     <% @results.each do |user| %>
-      <tr>
-        <td class='score hidden-phone'>
-          <%= "#{t :currency_symbol} #{user.total}" %>
-        </td>
-        <td class='email'><%= user.identifier %></td>
-        <td class='finishes'>
-          <i class='icon-award gold'></i>
-          <span><%= user.first %></span>
-          <i class='icon-award silver'></i>
-          <span><%= user.second %></span>
-          <i class='icon-award bronze'></i>
-          <span><%= user.third %></span>
-        </td>
-        <td class='percent'>
-          <%= (user.correct_ratio(@season) * 100).round(2) %>%
-        </td>
-      </tr>
+      <%# If the in_office param is set, and the user is not in office, %>
+      <%#   omit this user. %>
+      <% unless params[:in_office] && !user.in_office %>
+        <tr>
+          <td class='score hidden-phone'>
+            <%= "#{t :currency_symbol} #{user.total}" %>
+          </td>
+          <td class='email'><%= user.identifier %></td>
+          <td class='finishes'>
+            <i class='icon-award gold'></i>
+            <span><%= user.first %></span>
+            <i class='icon-award silver'></i>
+            <span><%= user.second %></span>
+            <i class='icon-award bronze'></i>
+            <span><%= user.third %></span>
+          </td>
+          <td class='percent'>
+            <%= (user.correct_ratio(@season) * 100).round(2) %>%
+          </td>
+        </tr>
+      <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/leader_boards/_switch_btn.html.erb
+++ b/app/views/leader_boards/_switch_btn.html.erb
@@ -1,0 +1,4 @@
+<%# Button to switch between the in-office and everybody versions of this page %>
+<% @btn_label = params[:in_office] ? :view_everybody_leader_board : :view_office_leader_board %>
+<%= link_to t(@btn_label), url_for(:in_office => params[:in_office] ? '' : 'in_office'), class: 'btn btn-default' %>
+

--- a/app/views/leader_boards/index.html.erb
+++ b/app/views/leader_boards/index.html.erb
@@ -2,4 +2,5 @@
 <h1><%= t :leader_board %></h1>
 <p><%= t '.info' %></p>
 <%= render "results" %>
-<%= link_to t(:overall_results_by_money), overall_money_leader_board_path, class: 'btn btn-default' %>
+<%= link_to t(:overall_results_by_money), overall_money_leader_board_path(in_office: params[:in_office]), class: 'btn btn-default' %>
+<%= render 'switch_btn' %>

--- a/app/views/leader_boards/money.html.erb
+++ b/app/views/leader_boards/money.html.erb
@@ -1,4 +1,5 @@
 <h1><%= t :leader_board %></h1>
 <p><%= t '.info' %></p>
 <%= render "results" %>
-<%= link_to t(:overall_results), overall_leader_board_path, class: 'btn btn-default' %>
+<%= link_to t(:overall_results), overall_leader_board_path(in_office: params[:in_office]), class: 'btn btn-default' %>
+<%= render 'switch_btn' %>

--- a/app/views/leader_boards/show.html.erb
+++ b/app/views/leader_boards/show.html.erb
@@ -53,6 +53,7 @@
   <% end %>
   </tbody>
 </table>
-<%= link_to t(:overall_results), overall_leader_board_path, class: 'btn btn-default' %>
-<%= link_to t(:overall_results_by_money), overall_money_leader_board_path, class: 'btn btn-default' %>
+<%= link_to t(:overall_results), overall_leader_board_path(in_office: params[:in_office]), class: 'btn btn-default' %>
+<%= link_to t(:overall_results_by_money), overall_money_leader_board_path(in_office: params[:in_office]), class: 'btn btn-default' %>
+<%= render 'switch_btn' %>
 

--- a/app/views/leader_boards/show.html.erb
+++ b/app/views/leader_boards/show.html.erb
@@ -13,39 +13,43 @@
   </thead>
   <tbody>
   <% @results.each do |result| %>
-    <tr class="<%= rank_class(result.position) %>">
-      <td class='score'>
-        <% if result.position == 1 %>
-          <%= icon 'award' %>
-        <% end %>
-        <%= "#{t :currency_symbol} #{result.total}" %>
-      </td>
-      <td class='email'><%= result.user.identifier %></td>
-      <% unless @game.answers.empty? %>
-        <td class='hidden-phone'>
-          <table class='breakdown'>
-            <thead>
-              <tr>
-                <% result.answers.each do %>
-                  <th></th>
-              <% end %>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <% @game.all_answers.zip(result.results).each do |(answer, result_type)| %>
-                  <td>
-                    <% unless result_type == :unavailable %>
-                      <%= link_to breakdown_icon(result_type), game_answer_path(@game, answer) %>
-                    <% end %>
-                  </td>
-                <% end %>
-              </tr>
-            </tbody>
-          </table>
+    <%# Only omit a user if we are showing the in office leaderboards %>
+    <%#   and they are not in office. %>
+    <% unless params[:in_office] && !result.user.in_office %>
+      <tr class="<%= rank_class(result.position) %>">
+        <td class='score'>
+          <% if result.position == 1 %>
+            <%= icon 'award' %>
+          <% end %>
+          <%= "#{t :currency_symbol} #{result.total}" %>
         </td>
-      <% end %>
-    </tr>
+        <td class='email'><%= result.user.identifier %></td>
+        <% unless @game.answers.empty? %>
+          <td class='hidden-phone'>
+            <table class='breakdown'>
+              <thead>
+                <tr>
+                  <% result.answers.each do %>
+                    <th></th>
+                <% end %>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <% @game.all_answers.zip(result.results).each do |(answer, result_type)| %>
+                    <td>
+                      <% unless result_type == :unavailable %>
+                        <%= link_to breakdown_icon(result_type), game_answer_path(@game, answer) %>
+                      <% end %>
+                    </td>
+                  <% end %>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
   <% end %>
   </tbody>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,21 @@ Imperilment::Application.routes.draw do
   end
   resources :web_hooks
 
-  get 'leader_board/money' => 'leader_boards#money', as: :overall_money_leader_board
-  get '/leader_board/overall' => 'leader_boards#index', as: :overall_leader_board
-  get '/leader_board(/:game_id)' => 'leader_boards#show', as: :leader_board
+  # Since the in_office parameter will only match `in_office`, it
+  #   acts as a optional URL modifier. I.e., '/leader_board/in_office/'
+  #   will use the same controller as '/leader_board/', but the first
+  #   one will have params[:in_office] set, which is used to filter
+  #   out people who are not in office.
+  # NOTE: game_id has to match a number because otherwise it would
+  #   be set to 'in_office'.
+  get 'leader_board/money(/:in_office)' => 'leader_boards#money',
+    as: :overall_money_leader_board,
+    constraints: { in_office: /in_office/ }
+  get '/leader_board/overall(/:in_office)' => 'leader_boards#index',
+    as: :overall_leader_board,
+    constraints: { in_office: /in_office/ }
+  get '/leader_board(/:game_id)(/:in_office)' => 'leader_boards#show',
+    as: :leader_board,
+    constraints: { in_office: /in_office/, game_id: /[0-9]+/ }
   root to: 'landing#show'
 end

--- a/db/migrate/20170726210225_add_in_office_to_users.rb
+++ b/db/migrate/20170726210225_add_in_office_to_users.rb
@@ -1,0 +1,5 @@
+class AddInOfficeToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :in_office, :boolean, {null: false, default: false}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150307173552) do
+ActiveRecord::Schema.define(version: 20170726210225) do
 
   create_table "answers", force: :cascade do |t|
     t.integer  "game_id"
@@ -76,8 +76,8 @@ ActiveRecord::Schema.define(version: 20150307173552) do
   add_index "roles", ["name"], name: "index_roles_on_name"
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 20150307173552) do
     t.datetime "updated_at"
     t.string   "first_name"
     t.string   "last_name"
+    t.boolean  "in_office",              default: false, null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
Allow admins to set users as in-office or not, and add separate leader boards for those who are in office. Close #26.

**Result:**
![office-leader-boards](https://user-images.githubusercontent.com/5296849/28684655-06434d94-72ba-11e7-9b0c-98a78dbdf554.gif)
